### PR TITLE
Add express backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
+# Carbon Wallet Backend
 
+This project now includes a simple Node.js Express backend that provides mock API routes used by the Carbon Wallet demo.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server with nodemon:
+   ```bash
+   npm run dev
+   ```
+   or start normally:
+   ```bash
+   npm start
+   ```
+
+The server listens on port `3000` by default and exposes the following routes:
+
+- `GET /api/users` - list all users
+- `GET /api/users/:id` - fetch a single user
+- `POST /api/users` - create a new user
+- `GET /api/rewards` - list available rewards
+- `POST /api/rewards/redeem` - redeem a reward
+- `GET /api/footprints` - list all carbon footprints
+- `POST /api/footprints` - add a new footprint record
+
+These routes operate on in-memory mock data and are intended for local development and testing.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "ellatso.github.io",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.10"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,79 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+
+// Mock data
+let users = [
+  { id: 1, name: 'Alice', carbonCredits: 120 },
+  { id: 2, name: 'Bob', carbonCredits: 80 }
+];
+
+let rewards = [
+  { id: 1, name: '10% discount', cost: 50 },
+  { id: 2, name: 'Free coffee', cost: 20 }
+];
+
+let footprints = [
+  { id: 1, userId: 1, amount: 12.5, date: '2024-05-01' },
+  { id: 2, userId: 2, amount: 7.0, date: '2024-05-03' }
+];
+
+// Routes
+app.get('/', (req, res) => {
+  res.send('Carbon Wallet API');
+});
+
+// User routes
+app.get('/api/users', (req, res) => {
+  res.json(users);
+});
+
+app.get('/api/users/:id', (req, res) => {
+  const user = users.find(u => u.id === Number(req.params.id));
+  if (!user) {
+    return res.status(404).json({ message: 'User not found' });
+  }
+  res.json(user);
+});
+
+app.post('/api/users', (req, res) => {
+  const newUser = { id: Date.now(), ...req.body };
+  users.push(newUser);
+  res.status(201).json(newUser);
+});
+
+// Rewards routes
+app.get('/api/rewards', (req, res) => {
+  res.json(rewards);
+});
+
+app.post('/api/rewards/redeem', (req, res) => {
+  const { userId, rewardId } = req.body;
+  const user = users.find(u => u.id === userId);
+  const reward = rewards.find(r => r.id === rewardId);
+  if (!user || !reward) {
+    return res.status(400).json({ message: 'Invalid user or reward' });
+  }
+  if (user.carbonCredits < reward.cost) {
+    return res.status(400).json({ message: 'Insufficient credits' });
+  }
+  user.carbonCredits -= reward.cost;
+  res.json({ message: 'Reward redeemed', user });
+});
+
+// Footprint routes
+app.get('/api/footprints', (req, res) => {
+  res.json(footprints);
+});
+
+app.post('/api/footprints', (req, res) => {
+  const newFootprint = { id: Date.now(), ...req.body };
+  footprints.push(newFootprint);
+  res.status(201).json(newFootprint);
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create basic Express server with mock data
- add API routes for users, rewards and footprints
- document API endpoints and setup
- add package.json and ignore node_modules

## Testing
- `node server.js &` then `curl -s http://localhost:3000/api/users`

------
https://chatgpt.com/codex/tasks/task_e_684f0a75612c8323ab04ae1a85f29e92